### PR TITLE
Update to Swift 5

### DIFF
--- a/GradientSlider/GradientSlider.swift
+++ b/GradientSlider/GradientSlider.swift
@@ -228,12 +228,12 @@ import UIKit
     
     //MARK: - Layout
     override var intrinsicContentSize:CGSize {
-        return CGSize(width: UIViewNoIntrinsicMetric, height: thumbSize)
+        return CGSize(width: UIView.noIntrinsicMetric, height: thumbSize)
     }
     
 //    func alignmentRectInsets() -> UIEdgeInsets {
     override var alignmentRectInsets: UIEdgeInsets {
-        return UIEdgeInsetsMake(4.0, 2.0, 4.0, 2.0)
+        return UIEdgeInsets(top: 4.0, left: 2.0, bottom: 4.0, right: 2.0)
     }
     
     override func layoutSublayers(of layer: CALayer) {
@@ -329,7 +329,7 @@ import UIKit
         let diameter = max(thumbSize,44.0)
         let r = CGRect(x: center.x - diameter/2.0, y: center.y - diameter/2.0, width: diameter, height: diameter)
         if r.contains(pt){
-            sendActions(for: UIControlEvents.touchDown)
+            sendActions(for: UIControl.Event.touchDown)
             return true
         }
         return false
@@ -341,7 +341,7 @@ import UIKit
         let newValue = valueForLocation(point: pt)
         setValue(newValue, animated: false)
         if(continuous){
-            sendActions(for: UIControlEvents.valueChanged)
+            sendActions(for: UIControl.Event.valueChanged)
             actionBlock(self,newValue,false)
         }
         return true
@@ -354,7 +354,7 @@ import UIKit
             setValue(newValue, animated: false)
         }
         actionBlock(self,_value,true)
-        sendActions(for: [UIControlEvents.valueChanged, UIControlEvents.touchUpInside])
+        sendActions(for: [UIControl.Event.valueChanged, UIControl.Event.touchUpInside])
         
     }
     


### PR DESCRIPTION
Changes:

* `UIViewNoIntrinsicMetric` becomes `UIView.noIntrinsicMetric`
* `UIEdgeInsetsMake` becomes `UIEdgeInsets`
* `UIControlEvents` becomes `UIControl.Event`